### PR TITLE
feat: 添加水印图片的保存方式及存储路径

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,18 @@ import { IPluginConfig } from "picgo/dist/src/utils/interfaces";
 
 import {IConfig} from './util'
 
+export enum WmImageFilePathType {
+  picGoBase = '默认目录',
+  originImageBase = '原文件所在目录'
+}
+
+export enum WmImageSaveType {
+  abandon = '删除水印图片',
+  replaceOrigin = '替换原文件',
+  originNameWithTimestamp = '使用原文件名称+时间戳',
+  renameOrigin = '使用原文件名称，原文件重命名'
+}
+
 export const config: (ctx: Picgo) => IPluginConfig[] = ctx => {
   let userConfig = ctx.getConfig<IConfig>("picgo-plugin-watermark");
   if (!userConfig) {
@@ -14,8 +26,11 @@ export const config: (ctx: Picgo) => IPluginConfig[] = ctx => {
       minSize: '',
       position: '',
       text: '',
+      wmImageFilePathType: WmImageFilePathType.picGoBase,
+      wmImageSaveType: WmImageSaveType.abandon,
     };
   }
+
   return [
     {
       name: "fontFamily",
@@ -72,6 +87,24 @@ export const config: (ctx: Picgo) => IPluginConfig[] = ctx => {
       required: false,
       message: "最小尺寸限制，小于这一尺寸不添加水印。E.g.200*200",
       alias: "最小尺寸"
+    },
+    {
+      name: "wmImageFilePathType",
+      type: "list",
+      choices: Object.values(WmImageFilePathType),
+      default: userConfig.wmImageFilePathType || WmImageFilePathType.picGoBase,
+      required: false,
+      message: "请选择水印图片临时文件存储位置",
+      alias: "水印图片临时文件存储位置"
+    },
+    {
+      name: "wmImageSaveType",
+      type: "list",
+      choices: Object.values(WmImageSaveType),
+      default: userConfig.wmImageSaveType || WmImageSaveType.abandon,
+      required: false,
+      message: "请选择水印图片存储方式",
+      alias: "水印图片存储方式"
     }
   ];
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,10 @@ const handle = async (ctx: Picgo): Promise<Picgo | boolean> => {
       minWidth,
       minHeight,
       textColor,
+      wmImageFilePathType,
+      wmImageSaveType,
     }
-  ] = parseAndValidate(userConfig);
+  ] = parseAndValidate(userConfig, ctx.log);
 
   // Verify configuration
   if (errors.length) {
@@ -65,7 +67,9 @@ const handle = async (ctx: Picgo): Promise<Picgo | boolean> => {
         minHeight,
         minWidth,
         position,
-        waterMark
+        waterMark,
+        wmImageFilePathType,
+        wmImageSaveType,
       },
       ctx.log
     );

--- a/src/input.ts
+++ b/src/input.ts
@@ -6,6 +6,7 @@ import sharp from "sharp";
 import path from "path";
 import Logger from "picgo/dist/src/lib/Logger";
 import { getCoordinateByPosition, PositionType, getImageBufferData } from "./util";
+import {WmImageFilePathType, WmImageSaveType} from "./config";
 
 interface IInput {
   input: any[];
@@ -13,6 +14,8 @@ interface IInput {
   minHeight: number;
   position: string;
   waterMark: string | Buffer;
+  wmImageFilePathType?: WmImageFilePathType;
+  wmImageSaveType?: WmImageSaveType;
 }
 
 export const inputAddWaterMarkHandle: (
@@ -20,7 +23,7 @@ export const inputAddWaterMarkHandle: (
   iinput: IInput,
   logger: Logger
 ) => Promise<string[]> = async (ctx, imageInput, logger) => {
-  const { input, minWidth, minHeight, waterMark, position } = imageInput;
+  const { input, minWidth, minHeight, waterMark, position, wmImageFilePathType, wmImageSaveType } = imageInput;
   const sharpedWaterMark = sharp(waterMark);
   const waterMarkMeta = await sharpedWaterMark.metadata();
 
@@ -65,14 +68,73 @@ export const inputAddWaterMarkHandle: (
           // not a clipboard image, generate a new file to save watermark image
           // 如果不是剪切板图片，说明图片为通过拖拽或选择的本地图片、或者是网络图片的url，需要在 picgo 目录下生成一个图片
           // 用于存放添加水印后的图片
-          const extname = format || path.extname(image) || 'png'
-          addWaterMarkImagePath = path.join(ctx.baseDir, `${dayjs().format('YYYYMMDDHHmmss')}.${extname}`)
+          const originExtname = path.extname(image)
+          const extname = format || originExtname || 'png'
+          const baseName = path.basename(image, `${originExtname}`)
+          logger.info(`图片文件全名：${baseName}，图片类型：${extname}，文件名：${baseName}，文件后缀：${originExtname}`)
 
+          let basePath
+          switch (wmImageFilePathType) {
+            case WmImageFilePathType.originImageBase:
+              basePath = path.dirname(image)
+              break;
+            default:
+              basePath = ctx.baseDir
+              break
+          }
+
+          addWaterMarkImagePath = path.join(
+            basePath,
+            `${baseName}_${dayjs().format('YYYYMMDDHHmmss')}.${extname}`
+          )
+          logger.info(`图片路径: ${addWaterMarkImagePath}`)
+
+          switch (wmImageSaveType) {
+            case WmImageSaveType.replaceOrigin:
+              addWaterMarkImagePath = image
+              break
+            case WmImageSaveType.renameOrigin:
+              ctx.once('finished', () => {
+                let originImageTargetPath = path.join(
+                  path.dirname(image),
+                  `${baseName}_o_${dayjs().format('YYYYMMDDHHmmss')}.${extname}`
+                )
+                fs.copyFile(image, originImageTargetPath, function (err) {
+                  if(err) {
+                    logger.info(JSON.stringify(coordinate));
+                    ctx.emit("notification", {
+                      title: "原文件复制失败",
+                      body: "原文件从" + image + "复制到" + originImageTargetPath + "失败"
+                    })
+                    return
+                  }
+                  fs.copyFile(addWaterMarkImagePath, image, function (err) {
+                    if(err) {
+                      logger.info(JSON.stringify(coordinate));
+                      ctx.emit("notification", {
+                        title: "水印文件失败",
+                        body: "水印文件从" + addWaterMarkImagePath + "复制到" + image + "失败"
+                      })
+                      return
+                    }
+                  })
+                })
+              })
+              break
+            case WmImageSaveType.originNameWithTimestamp:
+              addWaterMarkImagePath = path.join(
+                path.dirname(image),
+                `${baseName}_${dayjs().format('YYYYMMDDHHmmss')}.${extname}`
+              )
+              break
+            default:
+              ctx.once('finished', () => {
+                // 删除 picgo 生成的图片文件，例如 `~/.picgo/20200621205720.png`
+                fs.remove(addWaterMarkImagePath).catch((e) => { ctx.log.error(e) })
+              })
+              break
+          }
           ctx.once('failed', () => {
-            // 删除 picgo 生成的图片文件，例如 `~/.picgo/20200621205720.png`
-            fs.remove(addWaterMarkImagePath).catch((e) => { ctx.log.error(e) })
-          })
-          ctx.once('finished', () => {
             // 删除 picgo 生成的图片文件，例如 `~/.picgo/20200621205720.png`
             fs.remove(addWaterMarkImagePath).catch((e) => { ctx.log.error(e) })
           })
@@ -91,5 +153,8 @@ export const inputAddWaterMarkHandle: (
       return addWaterMarkImagePath
     })
   );
+
+  logger.info('图片处理完毕')
+
   return addedWaterMarkInput;
 };


### PR DESCRIPTION
增加水印图片的存储路径和保留方式，可以与folder-name之类的本地目录插件结合使用。

![image](https://user-images.githubusercontent.com/5778900/146880918-0699f670-e9eb-4a24-bc9f-b3698552f301.png)

支持的选项包括：

-   文件存储路径：
1. 默认目录
2. 原文件所在目录
-   水印文件保留方式：
1. 删除水印图片
2. 替换原文件
3. 使用原文件名称+时间戳
4. 使用原文件名称，原文件重命名